### PR TITLE
INFRA-5102 Add missing s3 permission

### DIFF
--- a/modules/transfer-users/main.tf
+++ b/modules/transfer-users/main.tf
@@ -58,6 +58,7 @@ resource "aws_iam_role_policy" "sftp_user_policies" {
         Action = [
           "s3:PutObject",
           "s3:GetObject",
+          "s3:GetObjectVersion",
           "s3:DeleteObject"
         ]
         Resource = ["${var.s3_bucket_arn}/*"]


### PR DESCRIPTION
Add S3 permissions so user can get files from Transfer Family (which are stored on a versioned S3 bucket).