### PR TITLE
chore: add stale workflow for PR management

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "10 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on:
+      group: arc-large-arm64-runner
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
+        with:
+          start-date: "2024-11-05T00:00:00Z"
+          stale-pr-message: "This PR is stale because it has been open 4 days with no activity. Remove stale label or comment or this will be closed in 4 days."
+          close-pr-message: "This PR was closed because it has been stalled for 7 days with no activity."
+          # No issue should be closed because of Github Projects used in Devops team
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 4
+          days-before-pr-close: 8
+          delete-branch: true
+          operations-per-run: 50


### PR DESCRIPTION
## Description
  This PR adds the stale workflow from the infrastructure repository to help automatically manage stale PRs.

  ## Changes
  - Added `.github/workflows/stale.yml` workflow
  - Configures automatic stale PR management:
    - PRs marked stale after 4 days of inactivity
    - Stale PRs closed after 8 days total
    - Issues are not affected by this workflow

  ## Testing
  - Workflow will run on schedule (daily at 07:10 UTC)
  - Can be manually triggered via workflow_dispatch

  ## References
  - Source: worldcoin/infrastructure repository
  - Workflow: `.github/workflows/stale.yml`